### PR TITLE
replace deprecated package

### DIFF
--- a/src/VTKDataTypes.jl
+++ b/src/VTKDataTypes.jl
@@ -5,7 +5,7 @@ using WriteVTK
 using PyGen
 using GeometryTypes
 using Colors
-using Iterators
+using IterTools
 
 include("vtkcelltypes.jl")
 include("types.jl")


### PR DESCRIPTION
First of all, hello and thanks for your package.
It is working fine on Arch Linux with Julia 0.6, Python 3.6.2 and VTK 8.0. Only thing I needed to do was to update this dependency, since Iterators.jl is deprecated and it was breaking the precompilation of your package.